### PR TITLE
Fixes datepicker from jumping to 1970 or 2070

### DIFF
--- a/phplib/base.php
+++ b/phplib/base.php
@@ -67,7 +67,8 @@ function getTimezoneSetting() {
 }
 
 function getWeekRange($date) {
-    $date = array_shift(explode('(', $date));
+    $date_bits = explode('(', $date);
+    $date = array_shift($date_bits);
     $ts = strtotime($date);
     $target_start = (date('l', $ts) == "Monday") ? "monday" : "last monday";
     $target_end = (date('l', $ts) == "Sunday") ? "sunday" : "next sunday";
@@ -85,7 +86,8 @@ function getOnCallWeekRange($date) {
     $oncall_start_time = getTeamOncallConfig('start');
     $oncall_end_time = getTeamOncallConfig('end');
 
-    $date = array_shift(explode('(', $date));
+    $date_bits = explode('(', $date);
+    $date = array_shift($date_bits);
     $ts = strtotime($date);
     // If we're still in the report week, we need to make sure we don't skip forward to the next oncall
     // week otherwise the two become mismatched. 
@@ -104,7 +106,8 @@ function getOnCallWeekRangeWithTZ($date) {
     $oncall_start_time = getTeamOncallConfig('start');
     $oncall_end_time = getTeamOncallConfig('end');
 
-    $date = array_shift(explode('(', $date));
+    $date_bits = explode('(', $date);
+    $date = array_shift($date_bits);
     $ts = strtotime($date);
     $ts = ( date('l', $ts) == "Saturday" || date('l', $ts) == "Sunday" ) ? $ts = $ts - 172800: $ts;
     date_default_timezone_set($oncall_timezone);


### PR DESCRIPTION
When $date is passed from the datepicker as

Fri Jul 04 2014 10:00:00 GMT+1000 (AUS Eastern Standard Time)

The timezone on the end causes $ts to be blank.

Strip the bracketed timezone from date before strtotime()

This seems to fix it in our environment, hopefully it doesnt break it elsewhere!
