### PR TITLE
PagerDuty pagination

### DIFF
--- a/providers/oncall/pagerduty.php
+++ b/providers/oncall/pagerduty.php
@@ -61,7 +61,13 @@ function getOnCallNotifications($name, $global_config, $team_config, $start, $en
 	    if (count($incidents->incidents) == 0) {
 		return array();
 	    }
+	    logline("Total incidents: " . $incidents->total);
+	    logline("Limit in this request: " . $incidents->limit);
+	    logline("Offset: " . $incidents->offset);
+
 	    $running_total += count($incidents->incidents);
+
+	    logline("Running total: " . $running_total);
 	    foreach ($incidents->incidents as $incident) {
 		$time = strtotime($incident->created_on);
 


### PR DESCRIPTION
PagerDuty returns a max of 100 incidents at a time; if there are more than 100, it indicates this with the "total" and "offset" variables returned with the request.  This code accounts for this, looping through to get all the incidents.  Things must be preeeetty easy at Etsy...:-)

I've also thrown in a bit of logging; feel free to leave that out if it's not appropriate.

Thanks very much!
