### PR TITLE
Add support for multiple PagerDuty Services

### DIFF
--- a/phplib/config.php.example
+++ b/phplib/config.php.example
@@ -86,7 +86,10 @@ $teams = array(
         "oncall" => array(
             "provider" => "pagerduty",
             "provider_options" => array(
+                // Single PagerDuty Service id
                 "pagerduty_service_id" => 'AB12CDE',
+                // Multiple PagerDuty Service ids are set in the format array('XXYYZZ1', 'AABBCC2') etc...
+                // "pagerduty_service_id" => array('AB12CDE', 'CC23DDE'),
             ),
             "timezone" => "America/New_York",
             "start" => "monday 12:00",


### PR DESCRIPTION
-- More // hints in config file on how to properly setup single/multiple service ids
-- If Single service_id, convert it to an array. If Multiple service_id, don't do anything
-- Sanitize the service_id. It should be 7 characters A-Z0-9
-- Add additional logging
-- Refactor the check if there are zero incidents (previously it breaks from the function).
