### PR TITLE
Update GitHub hints to support API based requests

### DIFF
--- a/providers/weekly/github.php
+++ b/providers/weekly/github.php
@@ -28,9 +28,12 @@ class GithubHints {
         $this->username = $username;
         $this->events_from = $events_from;
         $this->events_to = $events_to;
-        $this->github_token = $config['github_token'];
+        if(isset($config['github_token'])) {
+            $this->github_token = $config['github_token'];
+        } else {
+            $this->github_token = false;
+        }
     }
-
 
     public function printHints() {
         if(!$activities = $this->getGithubActivity()) {
@@ -90,6 +93,5 @@ class GithubHints {
             return $gh_activity;
         }
     }
-
 }
 ?>


### PR DESCRIPTION
This is required for GitHub enterprise editions that require authentication. I was unable to make this work using the direct github.com/username.json format, so this uses the github.com/api/v3/users/username format. The associated list is created using a slightly different JSON format as well. This should work happily alongside existing implementations with no impact (in theory).