### PR TITLE
Removing import of nonexistent stylesheet.

### DIFF
--- a/assets/bootstrap-wysihtml5.js
+++ b/assets/bootstrap-wysihtml5.js
@@ -450,7 +450,7 @@
                 "pre": 1
             }
         },
-        stylesheets: ["./lib/css/wysiwyg-color.css"], // (path_to_project/lib/css/wysiwyg-color.css)
+        stylesheets: [],
         locale: "en"
     };
 


### PR DESCRIPTION
This fixes #36 - a 404 error in the console on pages using wysihtml5. 