### PR TITLE
Jira provider doesn't work if username is different than that used in Opsweekly

### DIFF
--- a/edit_profile.php
+++ b/edit_profile.php
@@ -34,6 +34,7 @@ if (isset($_GET['succ'])) {
             <fieldset>
             <legend>User details</legend>
             <label>Full Name</label><input type="text" placeholder="Bob Robertson" name="full_name" value="<?php echo $profile['full_name']; ?>">
+            <label>Jira Username</label><input type="text" placeholder="username@yourcompany.com" name="jira_username" value="<?php echo $profile['jira_username']; ?>">
             <label>Time Zone</label>
             <select name="timezone">
                 <option></option>

--- a/opsweekly.sql
+++ b/opsweekly.sql
@@ -48,6 +48,7 @@ CREATE TABLE `meeting_notes` (
 CREATE TABLE `user_profile` (
     `ldap_username` varchar(255) NOT NULL,
     `full_name` varchar(255) NOT NULL,
+    `jira_username` varchar(255) NOT NULL,
     `timezone` varchar(10) NOT NULL,
     `sleeptracking_provider` varchar(255) NOT NULL,
     `sleeptracking_settings` text NOT NULL,

--- a/phplib/base.php
+++ b/phplib/base.php
@@ -209,6 +209,7 @@ class db {
     static function fetch_all($stmt) {
         if (!self::$dbh) self::connect();
         if (!self::$dbh) return false;
+        $return = [];
         if (self::$dbh instanceof mysqli) {
             while($result = $stmt->fetch_assoc()) {
                 $return[] = $result;
@@ -220,6 +221,13 @@ class db {
         }
         return $return;
     }
+}
+
+function getJiraUsernameFromDb() {
+    $myusername = getUsername();
+    $query = "SELECT jira_username FROM opsweekly.user_profile WHERE ldap_username='{$myusername}';";
+    $results = db::query($query);
+    return db::fetch_assoc($results)['jira_username'];
 }
 
 function insertNotify($level, $message) {

--- a/phplib/config.php.example
+++ b/phplib/config.php.example
@@ -144,8 +144,8 @@ $weekly_providers = array(
         "lib" => "providers/weekly/jira.php",
         "class"=> "JIRAHints",
         "options" => array(
-            "jira_api_url" => "https://jira.mycompany.com/rest/api/2",
-            "jira_url" => "https://jira.mycompany.com",
+            "jira_api_url" => "https://mycompany.atlassian.net/rest/api/latest",
+            "jira_url" => "https://mycompany.atlassian.net.net",
             "username" => "jira_api_login",
             "password" => "jira_api_password",
         ),

--- a/phplib/config.php.example
+++ b/phplib/config.php.example
@@ -145,7 +145,7 @@ $weekly_providers = array(
         "class"=> "JIRAHints",
         "options" => array(
             "jira_api_url" => "https://mycompany.atlassian.net/rest/api/latest",
-            "jira_url" => "https://mycompany.atlassian.net.net",
+            "jira_url" => "https://mycompany.atlassian.net",
             "username" => "jira_api_login",
             "password" => "jira_api_password",
         ),

--- a/providers/weekly/jira.php
+++ b/providers/weekly/jira.php
@@ -26,18 +26,16 @@ class JIRAHints {
     private $jira_context;
 
     public function __construct($username, $config, $events_from, $events_to) {
-        $this->username = $username;
+        $this->username = str_replace('@', '\u0040', getJiraUsernameFromDb());
         $this->events_from = $events_from;
         $this->events_to = $events_to;
         $this->jira_api_url = $config['jira_api_url'];
         $this->jira_url = $config['jira_url'];
-
         $this->jira_context = stream_context_create(array(
             'http' => array(
                 'header'  => "Authorization: Basic " . base64_encode("{$config['username']}:{$config['password']}")
             )
         ));
-
     }
 
     public function printHints() {
@@ -49,7 +47,6 @@ class JIRAHints {
         $search = rawurlencode("assignee = {$user} AND updated >= -{$days}days AND Status != New ORDER BY updated DESC, key DESC");
         $json = file_get_contents("{$this->jira_api_url}/search?jql={$search}", false, $this->jira_context);
         $decoded = json_decode($json);
-
         return $decoded;
     }
 
@@ -59,7 +56,6 @@ class JIRAHints {
         $search = rawurlencode($search);
         $json = file_get_contents("{$this->jira_api_url}/search?jql={$search}", false, $this->jira_context);
         $decoded = json_decode($json);
-
         return $decoded;
     }
 
@@ -84,7 +80,6 @@ class JIRAHints {
         // JIRA wants milliseconds instead of seconds since epoch
         $range_start = $this->events_from * 1000;
         $range_end = $this->events_to * 1000;
-
         $tickets = $this->getJIRAForPeriod($range_start, $range_end);
         if ($tickets->total > 0) {
             $html = "<ul>";
@@ -98,13 +93,7 @@ class JIRAHints {
             # No tickets found
             return insertNotify("error", "No JIRA activity for this period was found");
         }
-
     }
-
 }
 
-
-
-
 ?>
-

--- a/providers/weekly/jira.php
+++ b/providers/weekly/jira.php
@@ -26,7 +26,12 @@ class JIRAHints {
     private $jira_context;
 
     public function __construct($username, $config, $events_from, $events_to) {
-        $this->username = str_replace('@', '\u0040', getJiraUsernameFromDb());
+        $jusername_fromdb = getJiraUsernameFromDb();
+        if (!($jusername_fromdb == NULL)) {
+            $this->username = str_replace('@', '\u0040', getJiraUsernameFromDb());
+        } else {
+            $this->username = $username;
+        }
         $this->events_from = $events_from;
         $this->events_to = $events_to;
         $this->jira_api_url = $config['jira_api_url'];

--- a/save_profile.php
+++ b/save_profile.php
@@ -7,12 +7,13 @@ if (!db::connect()) {
 } else {
     $username = getUsername();
     $full_name = db::escape($_POST['full_name']);
+    $jira_username = db::escape($_POST['jira_username']);
     $tz = db::escape($_POST['timezone']);
     $sleep_provider = db::escape($_POST['sleeptracking_provider']);
     $sleep_settings = db::escape(json_encode($_POST['sleeptracking']));
 
-    $query = "REPLACE INTO user_profile (ldap_username, full_name, timezone, sleeptracking_provider, sleeptracking_settings) 
-                                    VALUES ('$username', '$full_name', '$tz', '$sleep_provider', '$sleep_settings')";
+    $query = "REPLACE INTO user_profile (ldap_username, full_name, jira_username, timezone, sleeptracking_provider, sleeptracking_settings) 
+                                    VALUES ('$username', '$full_name', '$jira_username', '$tz', '$sleep_provider', '$sleep_settings')";
     if (!db::query($query)) {
         echo "Database update failed, error: " . db::error();
     } else {


### PR DESCRIPTION
If Jira username is different than that used in Opsweekly the weekly provider can't get the user activities. To make it work I've created a new column "jira_username" in  "user_profile" table and updated the user profile page to handle this new field.