### PR TITLE
Fixed Github provider

### DIFF
--- a/edit_profile.php
+++ b/edit_profile.php
@@ -35,6 +35,7 @@ if (isset($_GET['succ'])) {
             <legend>User details</legend>
             <label>Full Name</label><input type="text" placeholder="Bob Robertson" name="full_name" value="<?php echo $profile['full_name']; ?>">
             <label>Jira Username</label><input type="text" placeholder="username@yourcompany.com" name="jira_username" value="<?php echo $profile['jira_username']; ?>">
+            <label>GitHub Username</label><input type="text" placeholder="git_username" name="github_username" value="<?php echo $profile['github_username']; ?>">
             <label>Time Zone</label>
             <select name="timezone">
                 <option></option>

--- a/opsweekly.sql
+++ b/opsweekly.sql
@@ -49,6 +49,7 @@ CREATE TABLE `user_profile` (
     `ldap_username` varchar(255) NOT NULL,
     `full_name` varchar(255) NOT NULL,
     `jira_username` varchar(255) NOT NULL,
+    `github_username` varchar(255) NOT NULL,
     `timezone` varchar(10) NOT NULL,
     `sleeptracking_provider` varchar(255) NOT NULL,
     `sleeptracking_settings` text NOT NULL,

--- a/phplib/base.php
+++ b/phplib/base.php
@@ -228,6 +228,7 @@ function getJiraUsernameFromDb() {
     $query = "SELECT jira_username FROM opsweekly.user_profile WHERE ldap_username='{$myusername}';";
     $results = db::query($query);
     return db::fetch_assoc($results)['jira_username'];
+}
 
 function getGithubUsernameFromDb() {
     $myusername = getUsername();

--- a/phplib/base.php
+++ b/phplib/base.php
@@ -228,6 +228,12 @@ function getJiraUsernameFromDb() {
     $query = "SELECT jira_username FROM opsweekly.user_profile WHERE ldap_username='{$myusername}';";
     $results = db::query($query);
     return db::fetch_assoc($results)['jira_username'];
+
+function getGithubUsernameFromDb() {
+    $myusername = getUsername();
+    $query = "SELECT github_username FROM opsweekly.user_profile WHERE ldap_username='{$myusername}';";
+    $results = db::query($query);
+    return db::fetch_assoc($results)['github_username'];
 }
 
 function insertNotify($level, $message) {

--- a/phplib/config.php.example
+++ b/phplib/config.php.example
@@ -136,7 +136,8 @@ $weekly_providers = array(
         "lib" => "providers/weekly/github.php",
         "class" => "GithubHints",
         "options" => array(
-            "github_url" => "https://github.com",
+            "github_url" => "https://api.github.com",
+            "github_token" => "yourgithubtoken",
         ),
     ),
     "jira" => array(

--- a/providers/weekly/github.php
+++ b/providers/weekly/github.php
@@ -47,7 +47,6 @@ class GithubHints {
         if (count($activities) > 0) {
             $html = "<ul>";
             foreach ($activities as $activity) {
-                $repo_base = $activity->repo->name; 
                 $date_base = $activity->created_at;
                 # There are other activity types other than commit, but for now we'll pretend they don't exist.
                 # This block handles direct requests to github.com/username.json 
@@ -65,11 +64,12 @@ class GithubHints {
                 }
                 # This block handles requests via api URL
                 if(isset($activity->payload->commits)) {
+                    $friendly_name = $activity->repo->name; 
                     $url_base = "{$this->github_url}/{$activity->repo->name}/commit/";
                     foreach ($activity->payload->commits as $commit) {
                         if (((strtotime($date_base)) >= $this->events_from) && ((strtotime($date_base)) <= $this->events_to)) {
                             $html .= "<li><a href=\"{$url_base}{$commit->sha}\">";
-                            $html .= "{$repo_base}</a> - {$commit->message}</li>";
+                            $html .= "{$friendly_name}</a> - {$commit->message}</li>";
                         }
                     }
                 }

--- a/providers/weekly/github.php
+++ b/providers/weekly/github.php
@@ -22,7 +22,12 @@ class GithubHints {
     private $username;
     public function __construct($username, $config, $events_from, $events_to) {
         $this->github_url = $config['github_url'];
-        $this->username = getGithubUsernameFromDb();
+        $ghusername_fromdb = getGithubUsernameFromDb();
+        if (!($ghusername_fromdb == NULL)) {
+            $this->username = getGithubUsernameFromDb();
+        } else {
+            $this->username = $username;
+        }
         $this->events_from = $events_from;
         $this->events_to = $events_to;
         if(isset($config['github_token'])) {

--- a/save_profile.php
+++ b/save_profile.php
@@ -8,12 +8,13 @@ if (!db::connect()) {
     $username = getUsername();
     $full_name = db::escape($_POST['full_name']);
     $jira_username = db::escape($_POST['jira_username']);
+    $github_username = db::escape($_POST['github_username']);
     $tz = db::escape($_POST['timezone']);
     $sleep_provider = db::escape($_POST['sleeptracking_provider']);
     $sleep_settings = db::escape(json_encode($_POST['sleeptracking']));
 
-    $query = "REPLACE INTO user_profile (ldap_username, full_name, jira_username, timezone, sleeptracking_provider, sleeptracking_settings) 
-                                    VALUES ('$username', '$full_name', '$jira_username', '$tz', '$sleep_provider', '$sleep_settings')";
+    $query = "REPLACE INTO user_profile (ldap_username, full_name, jira_username, github_username, timezone, sleeptracking_provider, sleeptracking_settings) 
+                                    VALUES ('$username', '$full_name', '$jira_username', '$github_username', '$tz', '$sleep_provider', '$sleep_settings')";
     if (!db::query($query)) {
         echo "Database update failed, error: " . db::error();
     } else {


### PR DESCRIPTION
If Opsweekly username is different than GitHub username the application can't retrieve the user activities in Github. To make it work I've created a new column "github_username" in "user_profile" table and updated the user profile page to handle this new field. The user must add his github username in order to get his github activities. I've fixed also the github url in config.php.example since it didn't work.