### PR TITLE
Allow users to use different database names

### DIFF
--- a/phplib/base.php
+++ b/phplib/base.php
@@ -225,21 +225,21 @@ class db {
 
 function getJiraUsernameFromDb() {
     $myusername = getUsername();
-    $query = "SELECT jira_username FROM opsweekly.user_profile WHERE ldap_username='{$myusername}';";
+    $query = "SELECT jira_username FROM user_profile WHERE ldap_username='{$myusername}';";
     $results = db::query($query);
     return db::fetch_assoc($results)['jira_username'];
 }
 
 function getGithubUsernameFromDb() {
     $myusername = getUsername();
-    $query = "SELECT github_username FROM opsweekly.user_profile WHERE ldap_username='{$myusername}';";
+    $query = "SELECT github_username FROM user_profile WHERE ldap_username='{$myusername}';";
     $results = db::query($query);
     return db::fetch_assoc($results)['github_username'];
 }
 
 function getBitbucketUsernameFromDb() {
     $myusername = getUsername();
-    $query = "SELECT bitbucket_username FROM opsweekly.user_profile WHERE ldap_username='{$myusername}';";
+    $query = "SELECT bitbucket_username FROM user_profile WHERE ldap_username='{$myusername}';";
     $results = db::query($query);
     return db::fetch_assoc($results)['bitbucket_username'];
 }


### PR DESCRIPTION
As suggested in pull request #62 (https://github.com/etsy/opsweekly/pull/62#issuecomment-247898753) users can use different database names, since many teams can host different instances on one SQL server or might not be able to choose the MySQL database name on some hosting providers. So I've removed the database name from all weekly providers db connector functions. I've also tested this modification and everything worked as expected.