### PR TITLE
Fix Pagerduty provider from null list of notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: php
+dist: trusty
 php:
-  - 5.5
+  - 5.6
   - 5.4
+  - 7.0
+  - 7.1
   - hhvm
 install:
   - test -f ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini && echo "short_open_tag=On" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini || true

--- a/providers/oncall/pagerduty.php
+++ b/providers/oncall/pagerduty.php
@@ -37,101 +37,117 @@
 
 function getOnCallNotifications($name, $global_config, $team_config, $start, $end) {
     $base_url = $global_config['base_url'];
-    $username = $global_config['username'];
-    $password = $global_config['password'];
+    if(isset($global_config['username'])) {
+        $username = $global_config['username'];
+    } else {
+        $username = NULL;
+    }
+    if(isset($global_config['password'])) {
+        $password = $global_config['password'];
+    } else {
+        $password = NULL;
+    }
     $apikey = $global_config['apikey'];
     $service_id = $team_config['pagerduty_service_id'];
-
     if ($base_url !== '' && $username !== '' && $password !== '' && $service_id !== '') {
-      // convert single PagerDuty service, to array construct in order to hold multiple services.
-      if (!is_array($service_id)) {
-        $service_id = array($service_id);
-      }
-
-      // loop through all PagerDuty services
-      foreach ($service_id as $sid) {
-        // check if the service id is formated correctly
-        if (!sanitizePagerDutyServiceId($sid)) {
-            logline('Incorect format for PagerDuty Service ID: ' . $sid);
-            // skip to the next Service ID in the array
-            continue;
+        // convert single PagerDuty service, to array construct in order to hold multiple services.
+        if (!is_array($service_id)) {
+            $service_id = array($service_id);
         }
+        // loop through all PagerDuty services
+        foreach ($service_id as $sid) {
+            // check if the service id is formated correctly
+            if (!sanitizePagerDutyServiceId($sid)) {
+                logline('Incorect format for PagerDuty Service ID: ' . $sid);
+                // skip to the next Service ID in the array
+            continue;
+            }
+            // loop through PagerDuty's maximum incidents count per API request.
+            $running_total = 0;
+            do {
+            // Connect to the Pagerduty API and collect all incidents in the time period.
+                $parameters = array(
+                    'since' => date('c', $start),
+                    'service' => $sid,
+                    'until' => date('c', $end),
+                    'offset' => $running_total,
+                );
+                $incident_json = doPagerdutyAPICall('/incidents', $parameters, $base_url, $username, $password, $apikey);
+                if (!$incidents = json_decode($incident_json)) {
+                    return 'Could not retrieve incidents from Pagerduty! Please check your login details';
+                }
+                // skip if no incidents are recorded
+                if (count($incidents->incidents) == 0) {
+                    continue;
+                }
+                logline("Incidents on Service ID: " . $sid);
+                logline("Total incidents: " . $incidents->total);
+                logline("Limit in this request: " . $incidents->limit);
+                logline("Offset: " . $incidents->offset);
+                $running_total += count($incidents->incidents);
+                logline("Running total: " . $running_total);
+                foreach ($incidents->incidents as $incident) {
+                    $time = strtotime($incident->created_on);
+                    $state = $incident->urgency;
+                    // try to determine and set the service
+                    if (isset($incident->trigger_summary_data->subject)) {
+                        $service = $incident->trigger_summary_data->subject;
+                    } elseif (isset($incident->trigger_summary_data->SERVICEDESC)) {
+                        $service = $incident->trigger_summary_data->SERVICEDESC;
+                    } elseif (isset($incident->trigger_summary_data->extracted_fields->SERVICEDESC)) {
+                        $service = $incident->trigger_summary_data->extracted_fields->SERVICEDESC;
+                    } elseif (isset($incident->trigger_summary_data->details->Trigger->Namespace)) {
+                        $service = $incident->trigger_summary_data->details->Trigger->Namespace;
+                    } elseif (isset($incident->trigger_summary_data->contexts)) {
+                        $service = "Pingdom";
+                    } else {
+                        $service = "unknown";
+                    }
+                    $output = $incident->trigger_details_html_url;
+                    $output .= "\n";
+                    // Add to the output all the trigger_summary_data info
+                    foreach ($incident->trigger_summary_data as $key => $key_data) {
+                        if (isset($incident->trigger_summary_data->extracted_fields)) {
+                            foreach ($incident->trigger_summary_data->extracted_fields as $otherkey => $otherkey_data) {
+                                $output .= "{$key}: {$otherkey_data}\n";
+                            }
+                        } else {
+                            $output .= "{$key}: {$key_data}\n";
+                        }
+                    }
+                    if (isset($incident->url)) {
+                        $output .= $incident->url;
+                    } else {
+                        $output .= NULL;
+                    }
+                    // try to determine the hostname
+                    if (isset($incident->trigger_summary_data->HOSTNAME)) {
+                        $hostname = $incident->trigger_summary_data->HOSTNAME;
+                    } elseif (isset($incident->trigger_summary_data->details->Trigger->Dimensions[0]->value)) {
+                        $hostname = $incident->trigger_summary_data->details->Trigger->Dimensions[0]->value;
+                    } elseif (isset($incident->trigger_summary_data->details->host)) {
+                        $hostname = $incident->trigger_summary_data->details->host;
+                    } else {
+                        // fallback is to just say it was pagerduty that sent it in
+                        $hostname = "Pagerduty";
+                    }
 
-	// loop through PagerDuty's maximum incidents count per API request.
-        $running_total = 0;
-        do {
-	    // Connect to the Pagerduty API and collect all incidents in the time period.
-	    $parameters = array(
-		'since' => date('c', $start),
-		'service' => $sid,
-		'until' => date('c', $end),
-		'offset' => $running_total,
-	    );
-
-	    $incident_json = doPagerdutyAPICall('/incidents', $parameters, $base_url, $username, $password, $apikey);
-	    if (!$incidents = json_decode($incident_json)) {
-		return 'Could not retrieve incidents from Pagerduty! Please check your login details';
-	    }
-	    // skip if no incidents are recorded
-	    if (count($incidents->incidents) == 0) {
-                continue;
-	    }
-	    logline("Incidents on Service ID: " . $sid);
-	    logline("Total incidents: " . $incidents->total);
-	    logline("Limit in this request: " . $incidents->limit);
-	    logline("Offset: " . $incidents->offset);
-
-	    $running_total += count($incidents->incidents);
-
-	    logline("Running total: " . $running_total);
-	    foreach ($incidents->incidents as $incident) {
-		$time = strtotime($incident->created_on);
-		$state = $incident->urgency;
-
-		// try to determine and set the service
-		if (isset($incident->trigger_summary_data->subject)) {
-		  $service = $incident->trigger_summary_data->subject;
-		} elseif (isset($incident->trigger_summary_data->SERVICEDESC)) {
-		  $service = $incident->trigger_summary_data->SERVICEDESC;
-		} else {
-		  $service = "unknown";
-		}
-
-		$output = $incident->trigger_details_html_url;
-		$output .= "\n";
-
-		// Add to the output all the trigger_summary_data info
-		foreach ($incident->trigger_summary_data as $key => $key_data) {
-		  $output .= "$key: $key_data\n";
-		}
-
-		$output .= $incident->url;
-
-		// try to determine the hostname
-		if (isset($incident->trigger_summary_data->HOSTNAME)) {
-		  $hostname = $incident->trigger_summary_data->HOSTNAME;
-		} else {
-		  // fallback is to just say it was pagerduty that sent it in
-		  $hostname = "Pagerduty";
-		}
-
-		$notifications[] = array("time" => $time, "hostname" => $hostname, "service" => $service, "output" => $output, "state" => "$state");
-	    }
-        } while ($running_total < $incidents->total);
-      }
-      // if no incidents are reported, don't generate the table
-      if (count($notifications) == 0 ) {
-        return array();
-      } else {
-        return $notifications;
-      }
+                    $notifications[] = array("time" => $time, "hostname" => $hostname, "service" => $service, "output" => $output, "state" => $state);
+                }
+            } while ($running_total < $incidents->total);
+        }
+        // if no incidents are reported, don't generate the table
+        if (count($notifications) == 0 ) {
+            return array();
+        } else {
+            return $notifications;
+        }
     } else {
         return false;
     }
 }
 
 function doPagerdutyAPICall($path, $parameters, $pagerduty_baseurl, $pagerduty_username, $pagerduty_password, $pagerduty_apikey) {
-
     if (isset($pagerduty_apikey)) {
         $context = stream_context_create(array(
             'http' => array(
@@ -139,14 +155,12 @@ function doPagerdutyAPICall($path, $parameters, $pagerduty_baseurl, $pagerduty_u
             )
         ));
     } else {
-
         $context = stream_context_create(array(
             'http' => array(
                 'header'  => "Authorization: Basic " . base64_encode("$pagerduty_username:$pagerduty_password")
             )
         ));
     }
-
     $params = null;
     foreach ($parameters as $key => $value) {
         if (isset($params)) {
@@ -160,36 +174,28 @@ function doPagerdutyAPICall($path, $parameters, $pagerduty_baseurl, $pagerduty_u
 }
 
 function whoIsOnCall($schedule_id, $time = null) {
-
     $until = $since = date('c', isset($time) ? $time : time());
     $parameters = array(
         'since' => $since,
         'until' => $until,
         'overflow' => 'true',
     );
-
     $json = doPagerdutyAPICall("/schedules/{$schedule_id}/entries", $parameters);
-
     if (false === ($scheddata = json_decode($json))) {
         return false;
     }
-
     if ($scheddata->total == 0) {
         return false;
     }
-
     if ($scheddata->entries['0']->user->name == "") {
         return false;
     }
-
     $oncalldetails = array();
     $oncalldetails['person'] = $scheddata->entries['0']->user->name;
     $oncalldetails['email'] = $scheddata->entries['0']->user->email;
     $oncalldetails['start'] = strtotime($scheddata->entries['0']->start);
     $oncalldetails['end'] = strtotime($scheddata->entries['0']->end);
-
     return $oncalldetails;
-
 }
 
 function sanitizePagerDutyServiceId($service_id) {


### PR DESCRIPTION
The Pagerduty oncall provider sometimes doesn't retrieve the alerts, clicking on "I was oncall" it prints NULL.
I experienced this when I've added DYN dns to the list of services in Pagerduty (using the emails sent by DYN).
There is an open issue related to it on my docker-opsweekly repo: https://github.com/ninoabbate/docker-opsweekly/issues/1